### PR TITLE
Handle throws from the first middleware in a chain.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,20 +3,17 @@
 function runner(req, res, middlewares) {
   var context = this;
 
-  function wrapper(index) {
-    var middleware = middlewares && middlewares[index];
+  function makeWrapper(index) {
+    return function wrapper() {
+      var middleware = middlewares && middlewares[index];
 
-    if (!middleware || res.headersSent || !res.writable) {
-      return Promise.resolve();
-    }
-
-    return Promise.resolve(middleware.call(context, req, res))
-      .then(function () {
-        return wrapper(index + 1);
-      });
+      if (middleware && !res.headersSent && res.writable) {
+        return Promise.resolve(middleware.call(context, req, res)).then(makeWrapper(index + 1));
+      }
+    };
   }
 
-  return wrapper(0);
+  return Promise.resolve().then(makeWrapper(0));
 }
 
 module.exports = runner;


### PR DESCRIPTION
The fix also allowed a refactor to simplify the code.
